### PR TITLE
jekyll seems to run on [every] cloud9 ide change, remove the .c9 to save...

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,2 @@
 baseurl: /bone101
 timezone: America/New_York
-include: [.c9]


### PR DESCRIPTION
... some cpu cycles

Signed-off-by: Robert Nelson <robertcnelson@gmail.com>