### PR TITLE
_config.yml: jekyll: make sure to exclude the .c9 dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 baseurl: /bone101
 timezone: America/New_York
-include: [.c9]
+exclude: [.c9]


### PR DESCRIPTION
Signed-off-by: Robert Nelson <robertcnelson@gmail.com>